### PR TITLE
Fix: 페이지네이션 제대로 동작 안하는 버그 수정 

### DIFF
--- a/src/common/pagination/pagination-request.ts
+++ b/src/common/pagination/pagination-request.ts
@@ -32,5 +32,7 @@ export class PaginationRequest {
   @IsOptional()
   readonly take: number = 10;
 
-  skip: number = (this.page - 1) * this.take;
+  getSkip(): number {
+    return (this.page - 1) * this.take;
+  }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,6 +4,7 @@ import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
 import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
 import * as session from 'express-session';
 import * as passport from 'passport';
+import { ValidationPipe } from '@nestjs/common';
 
 declare const module: any;
 
@@ -32,6 +33,14 @@ async function bootstrap() {
     origin: ['http://localhost', 'http://127.0.0.1'],
     credentials: true,
   });
+
+  app.useGlobalPipes(
+    new ValidationPipe({
+      whitelist: true, // decorator(@)가 없는 속성이 들어오면 해당 속성은 제거하고 받아들입니다.
+      forbidNonWhitelisted: true, // DTO에 정의되지 않은 값이 넘어오면 request 자체를 막습니다.
+      transform: true, // request와 일치하는 class로 변환, 이 처리를 안하면 그냥 object로 넘어옴
+    }),
+  );
 
   const config = new DocumentBuilder()
     .setTitle('co-KKIRI')

--- a/src/repository/team-member.query-repository.ts
+++ b/src/repository/team-member.query-repository.ts
@@ -23,8 +23,8 @@ export class TeamMemberQueryRepository {
         'member.nickname as nickname',
         'member.profileImageUrl as profileImageUrl',
       ])
-      .limit(paginationRequest.getSkip())
-      .offset(paginationRequest.take)
+      .limit(paginationRequest.take)
+      .offset(paginationRequest.getSkip())
       .orderBy('team_member.updatedAt', paginationRequest.order)
       .getRawMany();
     return plainToInstance(GetAllTeamMembersTuple, teamMembers);

--- a/src/repository/team-member.query-repository.ts
+++ b/src/repository/team-member.query-repository.ts
@@ -23,8 +23,8 @@ export class TeamMemberQueryRepository {
         'member.nickname as nickname',
         'member.profileImageUrl as profileImageUrl',
       ])
-      .skip(paginationRequest.skip)
-      .take(paginationRequest.take)
+      .limit(paginationRequest.getSkip())
+      .offset(paginationRequest.take)
       .orderBy('team_member.updatedAt', paginationRequest.order)
       .getRawMany();
     return plainToInstance(GetAllTeamMembersTuple, teamMembers);


### PR DESCRIPTION
### 개요  
페이지네이션 제대로 동작 안하는 버그 수정 

### 예상 리뷰시간  
1분

### 상세내용
- getRawMany일때는 skip, take가 동작하지 않아서 교체
- request class로 받기 위해 transform 적용
- 이상한값이 포함되서 넘어가면 제외하는 옵션 활성화

### 특이사항
