### PR TITLE
나의 스터디 API 추가

### DIFF
--- a/src/controller/my-post-controller.ts
+++ b/src/controller/my-post-controller.ts
@@ -53,4 +53,18 @@ export class MyPostController {
     })
   }
 
+  @ApiOperation({ summary: '내가 완료한 스터디 목록' })
+  @ApiPaginatedResponse(PostListResponse)
+  @Get('/complete/list')
+  async getMyCompletedPost(@Query() paginationRequest: PaginationRequest, @Req() req)
+    : Promise<PaginationResponse<PostListResponse>> {
+    const { getMyCompletedPost, totalCount } = await this.postListService.getMyCompletedPost(paginationRequest, req.user.id);
+    return PaginationResponse.of({
+      data: PostListResponse.from(getMyCompletedPost),
+      options: paginationRequest,
+      totalCount
+    })
+  }
+
+
 }

--- a/src/controller/my-post-controller.ts
+++ b/src/controller/my-post-controller.ts
@@ -27,15 +27,27 @@ export class MyPostController {
     })
   }
 
-  @Roles('anyone')
   @ApiOperation({ summary: '내가 모집한 스터디 목록' })
   @ApiPaginatedResponse(PostListResponse)
   @Get('/recruit/list')
   async getMyRecruitedPost(@Query() paginationRequest: PaginationRequest, @Req() req)
     : Promise<PaginationResponse<PostListResponse>> {
-    const { getMyRecruitedPost, totalCount } = await this.postListService.getMyRecruitedPost(paginationRequest, 1);
+    const { getMyRecruitedPost, totalCount } = await this.postListService.getMyRecruitedPost(paginationRequest, req.user.id);
     return PaginationResponse.of({
       data: PostListResponse.from(getMyRecruitedPost),
+      options: paginationRequest,
+      totalCount
+    })
+  }
+
+  @ApiOperation({ summary: '내가 진행중인 스터디 목록' })
+  @ApiPaginatedResponse(PostListResponse)
+  @Get('/on-going/list')
+  async getMyOnGoingPost(@Query() paginationRequest: PaginationRequest, @Req() req)
+    : Promise<PaginationResponse<PostListResponse>> {
+    const { getMyOnGoingPost, totalCount } = await this.postListService.getMyOnGoingPost(paginationRequest, req.user.id);
+    return PaginationResponse.of({
+      data: PostListResponse.from(getMyOnGoingPost),
       options: paginationRequest,
       totalCount
     })

--- a/src/controller/my-post-controller.ts
+++ b/src/controller/my-post-controller.ts
@@ -17,13 +17,14 @@ export class MyPostController {
   @ApiOperation({ summary: '내가 신청한 스터디 목록' })
   @ApiPaginatedResponse(PostListResponse)
   @Get('/apply/list')
-  async getMyRecruitedPost(@Query() paginationRequest: PaginationRequest, @Req() req)
+  async getMyAppliedPost(@Query() paginationRequest: PaginationRequest, @Req() req)
     : Promise<PaginationResponse<PostListResponse>> {
-    const { getMyRecruitedPost, totalCount } = await this.postListService.getMyRecruitedPost(paginationRequest, req.user.id);
+    const { getMyAppliedPost, totalCount } = await this.postListService.getMyAppliedPost(paginationRequest, req.user.id);
     return PaginationResponse.of({
-      data: PostListResponse.from(getMyRecruitedPost),
+      data: PostListResponse.from(getMyAppliedPost),
       options: paginationRequest,
       totalCount
     })
   }
+
 }

--- a/src/controller/my-post-controller.ts
+++ b/src/controller/my-post-controller.ts
@@ -27,4 +27,18 @@ export class MyPostController {
     })
   }
 
+  @Roles('anyone')
+  @ApiOperation({ summary: '내가 모집한 스터디 목록' })
+  @ApiPaginatedResponse(PostListResponse)
+  @Get('/recruit/list')
+  async getMyRecruitedPost(@Query() paginationRequest: PaginationRequest, @Req() req)
+    : Promise<PaginationResponse<PostListResponse>> {
+    const { getMyRecruitedPost, totalCount } = await this.postListService.getMyRecruitedPost(paginationRequest, 1);
+    return PaginationResponse.of({
+      data: PostListResponse.from(getMyRecruitedPost),
+      options: paginationRequest,
+      totalCount
+    })
+  }
+
 }

--- a/src/repository/post-list.query-repository.ts
+++ b/src/repository/post-list.query-repository.ts
@@ -266,6 +266,46 @@ export class PostListQueryRepository {
       .where('team_member.member_id = :memberId', { memberId })
       .andWhere('team_member.invite_type = :teamInviteType', { teamInviteType: TeamInviteType.SELF })
   }
+
+  async getAllMyRecruitedPost(paginationRequest: PaginationRequest, memberId: number)
+    : Promise<GetAllPostListTuple[]> {
+    const myRecruitedPostInfo = await this.dataSource
+      .createQueryBuilder()
+      .from(Post, 'post')
+      .innerJoin(Member, 'member', 'member.id = post.member_id')
+      .leftJoin(PostScrap, 'post_scrap', 'post_scrap.post_id = post.id AND post_scrap.member_id = :memberId', { memberId })
+      .where('post.member_id = :memberId', { memberId })
+      .select([
+        'post.id as postId',
+        'post.type as type',
+        'post.recruitEndAt as recruitEndAt',
+        'post.progressWay as progressWay',
+        'post.title as title',
+        'post.position as positions',
+        'post.stack as stacks',
+        'member.nickname as nickname',
+        'member.profileImageUrl as profileImageUrl',
+        'post.viewCount as viewCount',
+        'post.commentCount as commentCount',
+        'CASE WHEN post_scrap.id IS NOT NULL THEN true ELSE false END as isScraped'
+      ])
+      .limit(paginationRequest.take)
+      .offset(paginationRequest.getSkip())
+      .orderBy('post.created_at', paginationRequest.order)
+      .getRawMany();
+    return plainToInstance(GetAllPostListTuple, myRecruitedPostInfo);
+  }
+
+  async getAllMyRecruitedPostCount(memberId: number): Promise<number> {
+    return await this.getMyRecruitedPostBaseQuery(memberId).getCount();
+  }
+
+  private getMyRecruitedPostBaseQuery(memberId: number) {
+    return this.dataSource
+      .createQueryBuilder()
+      .from(Post, 'post')
+      .where('post.member_id = :memberId', { memberId })
+  }
 }
 
 export class GetAllPostListTuple {

--- a/src/repository/post-list.query-repository.ts
+++ b/src/repository/post-list.query-repository.ts
@@ -223,9 +223,9 @@ export class PostListQueryRepository {
     return query;
   }
 
-  async getAllMyRecruitedPost(paginationRequest: PaginationRequest, memberId: number)
+  async getAllMyAppliedPost(paginationRequest: PaginationRequest, memberId: number)
     : Promise<GetAllPostListTuple[]> {
-    const myRecruitedPostInfo = await this.dataSource
+    const myAppliedPostInfo = await this.dataSource
       .createQueryBuilder()
       .from(Post, 'post')
       .innerJoin(Member, 'member', 'member.id = post.member_id')
@@ -251,14 +251,14 @@ export class PostListQueryRepository {
       .offset(paginationRequest.getSkip())
       .orderBy('post.created_at', paginationRequest.order)
       .getRawMany();
-    return plainToInstance(GetAllPostListTuple, myRecruitedPostInfo);
+    return plainToInstance(GetAllPostListTuple, myAppliedPostInfo);
   }
 
-  async getAllMyRecruitedPostCount(memberId: number): Promise<number> {
-    return await this.getMyRecruitedPostBaseQuery(memberId).getCount();
+  async getAllMyAppliedPostCount(memberId: number): Promise<number> {
+    return await this.getMyAppliedPostBaseQuery(memberId).getCount();
   }
 
-  private getMyRecruitedPostBaseQuery(memberId: number) {
+  private getMyAppliedPostBaseQuery(memberId: number) {
     return this.dataSource
       .createQueryBuilder()
       .from(Post, 'post')

--- a/src/repository/post-list.query-repository.ts
+++ b/src/repository/post-list.query-repository.ts
@@ -188,9 +188,9 @@ export class PostListQueryRepository {
     progressWay?: string,
     sortBy?: PostListSortBy
   ) {
-    let query = this.dataSource.createQueryBuilder().from(Post, 'post');
-    query = query.where('post.status = :status', { status: PostStatus.READY });
-    query = query.andWhere('post.deletedAt IS NULL');
+    let query = this.dataSource.createQueryBuilder().from(Post, 'post')
+      .where('post.status = :status', { status: PostStatus.READY })
+      .andWhere('post.deletedAt IS NULL');
 
     if (meetingType && meetingType !== PostListType.ALL) {
       query = query.andWhere('post.type= :type', { type: meetingType });

--- a/src/repository/post-list.query-repository.ts
+++ b/src/repository/post-list.query-repository.ts
@@ -24,6 +24,7 @@ export class PostListQueryRepository {
       .leftJoin(PostScrap, 'post_scrap', 'post_scrap.post_id = post.id AND post_scrap.member_id = :memberId', { memberId })
       .where('post.type = :type', { type: Type.STUDY })
       .andWhere('post.status = :status', { status: PostStatus.READY })
+      .andWhere('post.deletedAt IS NULL')
       .select([
         'post.id as postId',
         'post.type as type',
@@ -53,6 +54,7 @@ export class PostListQueryRepository {
       .leftJoin(PostScrap, 'post_scrap', 'post_scrap.post_id = post.id AND post_scrap.member_id = :memberId', { memberId })
       .where('post.type = :type', { type: Type.STUDY })
       .andWhere('post.status = :status', { status: PostStatus.READY })
+      .andWhere('post.deletedAt IS NULL')
       .select([
         'post.id as postId',
         'post.type as type',
@@ -81,6 +83,7 @@ export class PostListQueryRepository {
       .leftJoin(PostScrap, 'post_scrap', 'post_scrap.post_id = post.id AND post_scrap.member_id = :memberId', { memberId })
       .where('post.type = :type', { type: Type.PROJECT })
       .andWhere('post.status = :status', { status: PostStatus.READY })
+      .andWhere('post.deletedAt IS NULL')
       .select([
         'post.id as postId',
         'post.type as type',
@@ -109,6 +112,7 @@ export class PostListQueryRepository {
       .leftJoin(PostScrap, 'post_scrap', 'post_scrap.post_id = post.id AND post_scrap.member_id = :memberId', { memberId })
       .where('post.type = :type', { type: Type.PROJECT })
       .andWhere('post.status = :status', { status: PostStatus.READY })
+      .andWhere('post.deletedAt IS NULL')
       .select([
         'post.id as postId',
         'post.type as type',
@@ -185,7 +189,8 @@ export class PostListQueryRepository {
     sortBy?: PostListSortBy
   ) {
     let query = this.dataSource.createQueryBuilder().from(Post, 'post');
-    query = query.where('post.status = :status', { status: PostStatus.READY })
+    query = query.where('post.status = :status', { status: PostStatus.READY });
+    query = query.andWhere('post.deletedAt IS NULL');
 
     if (meetingType && meetingType !== PostListType.ALL) {
       query = query.andWhere('post.type= :type', { type: meetingType });
@@ -233,6 +238,7 @@ export class PostListQueryRepository {
       .leftJoin(PostScrap, 'post_scrap', 'post_scrap.post_id = post.id AND post_scrap.member_id = :memberId', { memberId })
       .where('team_member.member_id = :memberId', { memberId })
       .andWhere('team_member.invite_type = :teamInviteType', { teamInviteType: TeamInviteType.SELF })
+      .andWhere('post.deletedAt IS NULL')
       .select([
         'post.id as postId',
         'post.type as type',
@@ -265,6 +271,7 @@ export class PostListQueryRepository {
       .innerJoin(TeamMember, 'team_member', 'post.id = team_member.post_id')
       .where('team_member.member_id = :memberId', { memberId })
       .andWhere('team_member.invite_type = :teamInviteType', { teamInviteType: TeamInviteType.SELF })
+      .andWhere('post.deletedAt IS NULL')
   }
 
   async getAllMyRecruitedPost(paginationRequest: PaginationRequest, memberId: number)
@@ -275,6 +282,7 @@ export class PostListQueryRepository {
       .innerJoin(Member, 'member', 'member.id = post.member_id')
       .leftJoin(PostScrap, 'post_scrap', 'post_scrap.post_id = post.id AND post_scrap.member_id = :memberId', { memberId })
       .where('post.member_id = :memberId', { memberId })
+      .andWhere('post.deletedAt IS NULL')
       .select([
         'post.id as postId',
         'post.type as type',
@@ -305,6 +313,7 @@ export class PostListQueryRepository {
       .createQueryBuilder()
       .from(Post, 'post')
       .where('post.member_id = :memberId', { memberId })
+      .andWhere('post.deletedAt IS NULL')
   }
 
   async getAllMyOnGoingPost(paginationRequest: PaginationRequest, memberId: number)

--- a/src/service/post-list.service.ts
+++ b/src/service/post-list.service.ts
@@ -46,12 +46,12 @@ export class PostListService {
     return { postInfo, totalCount };
   }
 
-  async getMyRecruitedPost(paginationRequest: PaginationRequest, memberId: number) {
-    const myRecruitedPostTuples = await this.postListQueryRepository.getAllMyRecruitedPost(paginationRequest, memberId);
-    const totalCount = await this.postListQueryRepository.getAllMyRecruitedPostCount(memberId);
+  async getMyAppliedPost(paginationRequest: PaginationRequest, memberId: number) {
+    const myAppliedPostTuples = await this.postListQueryRepository.getAllMyAppliedPost(paginationRequest, memberId);
+    const totalCount = await this.postListQueryRepository.getAllMyAppliedPostCount(memberId);
 
-    const getMyRecruitedPost = myRecruitedPostTuples.map((postList) =>
+    const getMyAppliedPost = myAppliedPostTuples.map((postList) =>
       GetPostedList.from(postList));
-    return { getMyRecruitedPost, totalCount };
+    return { getMyAppliedPost, totalCount };
   }
 }

--- a/src/service/post-list.service.ts
+++ b/src/service/post-list.service.ts
@@ -54,4 +54,13 @@ export class PostListService {
       GetPostedList.from(postList));
     return { getMyAppliedPost, totalCount };
   }
+
+  async getMyRecruitedPost(paginationRequest: PaginationRequest, memberId: number) {
+    const myRecruitedPostTuples = await this.postListQueryRepository.getAllMyRecruitedPost(paginationRequest, memberId);
+    const totalCount = await this.postListQueryRepository.getAllMyRecruitedPostCount(memberId);
+
+    const getMyRecruitedPost = myRecruitedPostTuples.map((postList) =>
+      GetPostedList.from(postList));
+    return { getMyRecruitedPost, totalCount };
+  }
 }

--- a/src/service/post-list.service.ts
+++ b/src/service/post-list.service.ts
@@ -63,4 +63,13 @@ export class PostListService {
       GetPostedList.from(postList));
     return { getMyRecruitedPost, totalCount };
   }
+
+  async getMyOnGoingPost(paginationRequest: PaginationRequest, memberId: number) {
+    const myOnGoingPostTuples = await this.postListQueryRepository.getAllMyOnGoingPost(paginationRequest, memberId);
+    const totalCount = await this.postListQueryRepository.getAllMyOnGoingPostCount(memberId);
+
+    const getMyOnGoingPost = myOnGoingPostTuples.map((postList) =>
+      GetPostedList.from(postList));
+    return { getMyOnGoingPost, totalCount };
+  }
 }

--- a/src/service/post-list.service.ts
+++ b/src/service/post-list.service.ts
@@ -72,4 +72,13 @@ export class PostListService {
       GetPostedList.from(postList));
     return { getMyOnGoingPost, totalCount };
   }
+
+  async getMyCompletedPost(paginationRequest: PaginationRequest, memberId: number) {
+    const myCompletedPostTuples = await this.postListQueryRepository.getAllMyCompletedPost(paginationRequest, memberId);
+    const totalCount = await this.postListQueryRepository.getAllMyCompletedPostCount(memberId);
+
+    const getMyCompletedPost = myCompletedPostTuples.map((postList) =>
+      GetPostedList.from(postList));
+    return { getMyCompletedPost, totalCount };
+  }
 }


### PR DESCRIPTION
### 개요 
내가 [모집한, 진행중인, 완료한] 스터디 목록 API를 추가하였습니다.

### 예상 리뷰시간 
10분

### 상세내용
내가 모집한 스터디 = post테이블에 받아오는 유저의 id가 같은 스터디

내가 진행중인 스터디 = (포스트의 status가 모집완료이면서, 접속한 멤버가 포스트의 주인이거나)
(포스트의 status가 모집완료이면서, 해당 포스트의 팀멤버로 속해있고 팀 신청이 받아들여진 상태일 때)

내가 완료한 스터디 = (포스트의 status가 완료이면서, 접속한 멤버가 포스트의 주인이거나)
(포스트의 status가 완료이면서, 해당 포스트의 팀멤버로 속해있고 팀 신청이 받아들여진 상태일 때)

위의 로직으로 작성하였습니다.

### 특이사항
deletedAt 검증 쿼리를 추가하여, deletedAt이 있다면 목록에 뜨지 않게 만들었습니다.
추후 수정될 수 있습니다.
