### PR TITLE
스터디 상세 teamInviteId 추가

### DIFF
--- a/src/dto/get-post-detail.dto.ts
+++ b/src/dto/get-post-detail.dto.ts
@@ -3,15 +3,13 @@ import { GetAllPostDetailTuple } from "src/repository/post-detail.query-reposito
 
 export class GetPostDetailDto {
   postDetail!: GetPostDetails;
-  isScraped!: boolean;
   postApplyStatus!: PostApplyStatus;
 
-  constructor(postDetail: GetPostDetails, isScraped: boolean, postApplyStatus: PostApplyStatus) {
+  constructor(postDetail: GetPostDetails, postApplyStatus: PostApplyStatus) {
     this.postDetail = postDetail;
-    this.isScraped = isScraped;
     this.postApplyStatus = postApplyStatus;
   }
-  static from(tuple: GetAllPostDetailTuple, isScraped: boolean, postApplyStatus: PostApplyStatus) {
+  static from(tuple: GetAllPostDetailTuple, postApplyStatus: PostApplyStatus) {
     const postDetail = new GetPostDetails(
       tuple.postTitle,
       tuple.postMemberId,
@@ -28,11 +26,12 @@ export class GetPostDetailDto {
       tuple.positions,
       tuple.stacks,
       tuple.link,
+      tuple.isScraped,
       tuple.viewCount,
       tuple.scrapCount,
       tuple.commentCount,
     );
-    return new GetPostDetailDto(postDetail, isScraped, postApplyStatus);
+    return new GetPostDetailDto(postDetail, postApplyStatus);
   }
 }
 
@@ -52,6 +51,7 @@ export class GetPostDetails {
   positions: string[];
   stacks: string[];
   link: string;
+  isScraped!: boolean;
   viewCount!: number;
   scrapCount!: number;
   commentCount: number;
@@ -72,9 +72,11 @@ export class GetPostDetails {
     positions: string[],
     stack: string[],
     link: string,
+    isScraped: boolean,
     viewCount: number,
     scrapCount: number,
     commentCount: number,
+
   ) {
     this.postTitle = postTitle;
     this.postMemberId = postMemberId;
@@ -91,6 +93,7 @@ export class GetPostDetails {
     this.positions = positions;
     this.stacks = stack;
     this.link = link;
+    this.isScraped = isScraped;
     this.viewCount = viewCount;
     this.scrapCount = scrapCount;
     this.commentCount = commentCount;

--- a/src/dto/get-post-detail.dto.ts
+++ b/src/dto/get-post-detail.dto.ts
@@ -30,6 +30,7 @@ export class GetPostDetailDto {
       tuple.viewCount,
       tuple.scrapCount,
       tuple.commentCount,
+      tuple.teamInviteId,
     );
     return new GetPostDetailDto(postDetail, postApplyStatus);
   }
@@ -55,6 +56,7 @@ export class GetPostDetails {
   viewCount!: number;
   scrapCount!: number;
   commentCount: number;
+  teamInviteId?: number;
 
   constructor(
     postTitle: string,
@@ -76,6 +78,7 @@ export class GetPostDetails {
     viewCount: number,
     scrapCount: number,
     commentCount: number,
+    teamInviteId?: number
 
   ) {
     this.postTitle = postTitle;
@@ -97,5 +100,6 @@ export class GetPostDetails {
     this.viewCount = viewCount;
     this.scrapCount = scrapCount;
     this.commentCount = commentCount;
+    this.teamInviteId = teamInviteId;
   }
 }

--- a/src/dto/response/post-detail.response.ts
+++ b/src/dto/response/post-detail.response.ts
@@ -41,7 +41,8 @@ export class PostDetails {
   scrapCount!: number;
   @ApiProperty()
   commentCount!: number;
-
+  @ApiProperty()
+  teamInviteId?: number;
 
   constructor(
     postTitle: string,
@@ -63,6 +64,7 @@ export class PostDetails {
     viewCount: number,
     scrapCount: number,
     commentCount: number,
+    teamInviteId?: number,
 
   ) {
     this.postTitle = postTitle;
@@ -84,6 +86,7 @@ export class PostDetails {
     this.viewCount = viewCount;
     this.scrapCount = scrapCount;
     this.commentCount = commentCount;
+    this.teamInviteId = teamInviteId;
 
   }
 }
@@ -118,6 +121,7 @@ export class PostDetailResponse {
       dto.postDetail.viewCount,
       dto.postDetail.scrapCount,
       dto.postDetail.commentCount,
+      dto.postDetail.teamInviteId
     );
     return new PostDetailResponse(postDetails, dto.postApplyStatus);
   }

--- a/src/dto/response/post-detail.response.ts
+++ b/src/dto/response/post-detail.response.ts
@@ -34,11 +34,14 @@ export class PostDetails {
   @ApiProperty()
   link: string;
   @ApiProperty()
+  isScraped!: boolean;
+  @ApiProperty()
   viewCount!: number;
   @ApiProperty()
   scrapCount!: number;
   @ApiProperty()
   commentCount!: number;
+
 
   constructor(
     postTitle: string,
@@ -56,9 +59,11 @@ export class PostDetails {
     positions: string[],
     stacks: string[],
     link: string,
+    isScraped: boolean,
     viewCount: number,
     scrapCount: number,
     commentCount: number,
+
   ) {
     this.postTitle = postTitle;
     this.postMemberId = postMemberId;
@@ -75,20 +80,20 @@ export class PostDetails {
     this.positions = positions;
     this.stacks = stacks;
     this.link = link;
+    this.isScraped = isScraped;
     this.viewCount = viewCount;
     this.scrapCount = scrapCount;
     this.commentCount = commentCount;
+
   }
 }
 export class PostDetailResponse {
   @ApiProperty({ type: PostDetails })
   postDetails!: PostDetails;
-  isScraped!: boolean;
   postApplyStatus!: PostApplyStatus;
 
-  constructor(postDetails: PostDetails, isScraped: boolean, postApplyStatus: PostApplyStatus) {
+  constructor(postDetails: PostDetails, postApplyStatus: PostApplyStatus) {
     this.postDetails = postDetails;
-    this.isScraped = isScraped;
     this.postApplyStatus = postApplyStatus;
   }
 
@@ -109,11 +114,12 @@ export class PostDetailResponse {
       dto.postDetail.positions,
       dto.postDetail.stacks,
       dto.postDetail.link,
+      dto.postDetail.isScraped,
       dto.postDetail.viewCount,
       dto.postDetail.scrapCount,
       dto.postDetail.commentCount,
     );
-    return new PostDetailResponse(postDetails, dto.isScraped, dto.postApplyStatus);
+    return new PostDetailResponse(postDetails, dto.postApplyStatus);
   }
 
 }

--- a/src/repository/post-detail.query-repository.ts
+++ b/src/repository/post-detail.query-repository.ts
@@ -9,20 +9,19 @@ import { Member } from "src/entity/member.entity";
 import { PostScrap } from "src/entity/post-scrap.entity";
 import { PostView } from "src/entity/post-view.entity";
 import { Post } from "src/entity/post.entity";
+import { TeamMember } from 'src/entity/team-member.entity';
 import { DataSource } from "typeorm";
 
 @Injectable()
 export class PostDetailQueryRepository {
   constructor(@InjectDataSource() private readonly dataSource: DataSource) { }
 
-  async getAllPostDetails(postId: number) {
+  async getAllPostDetails(postId: number, memberId: number): Promise<GetAllPostDetailTuple> {
     const postDetail = await this.dataSource
       .createQueryBuilder()
       .from(Post, 'post')
       .innerJoin(Member, 'member', 'post.member_id = member.id')
-      .leftJoin(PostView, 'post_view', 'post_view.postId = post.id')
-      .leftJoin(PostScrap, 'post_scrap', 'post_scrap.post_id = post.id')
-      .leftJoin(Comment, 'comment', 'comment.post_id = post.id')
+      .leftJoin(PostScrap, 'post_scrap', 'post_scrap.post_id = post.id AND post_scrap.member_id = :memberId', { memberId })
       .where('post.id = :postId', { postId })
       .select([
         'post.title as postTitle',
@@ -40,6 +39,7 @@ export class PostDetailQueryRepository {
         'post.position as positions',
         'post.stack as stacks',
         'post.link as link',
+        'CASE WHEN post_scrap.id IS NOT NULL THEN true ELSE false END as isScraped',
         'post.viewCount as viewCount',
         'post.scrapCount as scrapCount',
         'post.commentCount as commentCount',
@@ -104,7 +104,6 @@ export class GetAllPostDetailTuple {
   createdAt!: Date;
   type!: Type;
   recruitEndAt: Date;
-  // TODO : 결정해지는 대로 enum으로 바꿔야함
   progressPeriod: string;
   progressWay: string;
   contactWay: string;
@@ -114,6 +113,8 @@ export class GetAllPostDetailTuple {
   positions: string[];
   @Transform(({ value }) => JSON.parse(value) || [])
   stacks: string[];
+  @Transform(({ value }) => value === '1')
+  isScraped!: boolean;
   @Transform(({ value }) => Number(value))
   @IsInt()
   viewCount: number;
@@ -123,7 +124,6 @@ export class GetAllPostDetailTuple {
   @Transform(({ value }) => Number(value))
   @IsInt()
   commentCount: number;
-
 }
 
 export class GetAllPostCommentTuple {

--- a/src/repository/post-detail.query-repository.ts
+++ b/src/repository/post-detail.query-repository.ts
@@ -17,7 +17,7 @@ import { DataSource } from "typeorm";
 export class PostDetailQueryRepository {
   constructor(@InjectDataSource() private readonly dataSource: DataSource) { }
 
-  async getAllPostDetails(postId: number, memberId: number): Promise<GetAllPostDetailTuple> {
+  async getAllPostDetails(postId: number, memberId?: number): Promise<GetAllPostDetailTuple> {
     const postDetail = await this.dataSource
       .createQueryBuilder()
       .from(Post, 'post')

--- a/src/repository/post-list.query-repository.ts
+++ b/src/repository/post-list.query-repository.ts
@@ -441,6 +441,6 @@ export class GetAllPostListTuple {
   @Transform(({ value }) => Number(value))
   @IsInt()
   commentCount!: number;
-  @Transform(({ value }) => value === 1)
+  @Transform(({ value }) => value === '1')
   isScraped!: boolean;
 }

--- a/src/service/post-detail.service.ts
+++ b/src/service/post-detail.service.ts
@@ -25,14 +25,9 @@ export class PostDetailService {
     @InjectRepository(PostScrap) private readonly postScrapRepository: Repository<PostScrap>,
     private readonly postDetailQueryRepository: PostDetailQueryRepository) { }
 
-  async getPostDetail(postId: number, memberId?: number): Promise<GetPostDetailDto> {
-    const post = await this.postDetailQueryRepository.getAllPostDetails(postId);
+  async getPostDetail(postId: number, memberId: number): Promise<GetPostDetailDto> {
+    const post = await this.postDetailQueryRepository.getAllPostDetails(postId, memberId);
 
-    let isScraped = false;
-    if (typeof memberId !== 'undefined') {
-      const isScrapedMember = await this.postScrapRepository.findOneBy({ postId, memberId });
-      isScraped = isScrapedMember !== null;
-    }
     const newViewCount = post.viewCount + 1;
     await this.postDetailQueryRepository.updateView(postId, newViewCount);
 
@@ -40,7 +35,7 @@ export class PostDetailService {
       postId: postId,
       memberId: memberId,
     });
-    return new GetPostDetailDto({ ...post, viewCount: newViewCount }, isScraped, await this.getPostApplyType(postId, memberId));
+    return new GetPostDetailDto({ ...post, viewCount: newViewCount }, await this.getPostApplyType(postId, memberId));
   }
 
   async getPostComments(postId: number, paginationRequest: PaginationRequest, memberId: number) {

--- a/src/service/post-detail.service.ts
+++ b/src/service/post-detail.service.ts
@@ -25,7 +25,7 @@ export class PostDetailService {
     @InjectRepository(PostScrap) private readonly postScrapRepository: Repository<PostScrap>,
     private readonly postDetailQueryRepository: PostDetailQueryRepository) { }
 
-  async getPostDetail(postId: number, memberId: number): Promise<GetPostDetailDto> {
+  async getPostDetail(postId: number, memberId?: number): Promise<GetPostDetailDto> {
     const post = await this.postDetailQueryRepository.getAllPostDetails(postId, memberId);
 
     const newViewCount = post.viewCount + 1;

--- a/src/service/post-detail.service.ts
+++ b/src/service/post-detail.service.ts
@@ -31,10 +31,12 @@ export class PostDetailService {
     const newViewCount = post.viewCount + 1;
     await this.postDetailQueryRepository.updateView(postId, newViewCount);
 
-    await this.postViewRepository.save({
-      postId: postId,
-      memberId: memberId,
-    });
+    if (typeof memberId !== 'undefined') {
+      await this.postViewRepository.save({
+        postId: postId,
+        memberId: memberId,
+      });
+    }
     return new GetPostDetailDto({ ...post, viewCount: newViewCount }, await this.getPostApplyType(postId, memberId));
   }
 


### PR DESCRIPTION
### 개요  
isScraped 구조를 변경하고, response에 teamInviteId를 추가했습니다.

### 예상 리뷰시간  1분

### 상세내용
team_invite.post_id = post.id
team_invite.send_member_id = post.member_id
team_invite.receive_memer_id = req.user.id

이 3가지 상황으로 로직을 구현하였고, 만약 그런 id가 없다면 null로 내려오게 만들었습니다. 

### 특이사항
