### PR TITLE
applyStatus관련 쿼리 수정

### DIFF
--- a/src/controller/my-post-controller.ts
+++ b/src/controller/my-post-controller.ts
@@ -4,6 +4,7 @@ import { PaginationRequest } from "src/common/pagination/pagination-request";
 import { PaginationResponse } from "src/common/pagination/pagination-response";
 import { ApiPaginatedResponse } from "src/common/pagination/pagination.decorator";
 import { Roles } from "src/common/roles/roles.decorator";
+import { PostCompleteListResponse } from "src/dto/response/post-complete-list.response";
 import { PostListResponse } from "src/dto/response/post-list-response";
 import { RolesGuard } from "src/guard/roles.guard";
 import { PostListService } from "src/service/post-list.service";
@@ -60,7 +61,7 @@ export class MyPostController {
     : Promise<PaginationResponse<PostListResponse>> {
     const { getMyCompletedPost, totalCount } = await this.postListService.getMyCompletedPost(paginationRequest, req.user.id);
     return PaginationResponse.of({
-      data: PostListResponse.from(getMyCompletedPost),
+      data: PostCompleteListResponse.from(getMyCompletedPost),
       options: paginationRequest,
       totalCount
     })

--- a/src/dto/get-post-complete.dto.ts
+++ b/src/dto/get-post-complete.dto.ts
@@ -1,0 +1,83 @@
+import { Type } from "src/entity/common/Enums";
+import { GetAllCompletePostListTuple } from "src/repository/post-list.query-repository";
+
+export class GetCompletePostListDto {
+  completePostInfo!: GetCompletePostedList[]
+
+  constructor(completePostInfo: GetCompletePostedList[]) {
+    this.completePostInfo = completePostInfo;
+  }
+
+  static from(tuples: GetAllCompletePostListTuple[]) {
+    const completePostInfo = tuples.map((tuple) => {
+      return GetCompletePostedList.from(tuple);
+    });
+    return new GetCompletePostListDto(completePostInfo);
+  }
+}
+
+
+
+export class GetCompletePostedList {
+  postId!: number;
+  type!: Type;
+  recruitEndAt: Date;
+  progressWay!: string;
+  title!: string;
+  positions: string[];
+  stacks: string[];
+  nickname: string;
+  profileImageUrl: string;
+  viewCount!: number;
+  commentCount!: number;
+  isScraped!: boolean;
+  postStatus!: string;
+
+  constructor(
+    postId: number,
+    type: Type,
+    recruitEndAt: Date,
+    progressWay: string,
+    title: string,
+    positions: string[],
+    stacks: string[],
+    nickname: string,
+    profileImageUrl: string,
+    postViews: number,
+    postCommentsNum: number,
+    isScraped: boolean,
+    postStatus: string,
+  ) {
+    this.postId = postId;
+    this.type = type;
+    this.recruitEndAt = recruitEndAt;
+    this.progressWay = progressWay;
+    this.title = title;
+    this.positions = positions;
+    this.stacks = stacks;
+    this.nickname = nickname;
+    this.profileImageUrl = profileImageUrl;
+    this.viewCount = postViews;
+    this.commentCount = postCommentsNum;
+    this.isScraped = isScraped;
+    this.postStatus = postStatus;
+  }
+
+  static from(tuple: GetAllCompletePostListTuple) {
+    return new GetCompletePostedList(
+      tuple.postId,
+      tuple.type,
+      tuple.recruitEndAt,
+      tuple.progressWay,
+      tuple.title,
+      tuple.positions,
+      tuple.stacks,
+      tuple.nickname,
+      tuple.profileImageUrl,
+      tuple.viewCount,
+      tuple.commentCount,
+      tuple.isScraped,
+      tuple.postStatus
+    );
+  }
+}

--- a/src/dto/response/post-complete-list.response.ts
+++ b/src/dto/response/post-complete-list.response.ts
@@ -1,0 +1,84 @@
+import { ApiProperty } from "@nestjs/swagger";
+import { Type } from "src/entity/common/Enums";
+import { GetCompletePostedList } from "../get-post-complete.dto";
+
+export class PostCompleteListResponse {
+  @ApiProperty()
+  postId!: number;
+  @ApiProperty()
+  type!: Type;
+  @ApiProperty()
+  recruitEndAt!: Date;
+  @ApiProperty()
+  progressWay!: string;
+  @ApiProperty()
+  title!: string;
+  @ApiProperty()
+  positions: string[];
+  @ApiProperty()
+  stacks: string[];
+  @ApiProperty()
+  nickname: string;
+  @ApiProperty()
+  profileImageUrl: string;
+  @ApiProperty()
+  viewCount!: number;
+  @ApiProperty()
+  commentCount!: number;
+  @ApiProperty()
+  isScraped!: boolean;
+  @ApiProperty()
+  postStatus!: string;
+
+  constructor(
+    postId: number,
+    type: Type,
+    recruitEndAt: Date,
+    progressWay: string,
+    title: string,
+    positions: string[],
+    stacks: string[],
+    nickname: string,
+    profileImageUrl: string,
+    viewCount: number,
+    commentCount: number,
+    isScraped: boolean,
+    postStatus: string,
+  ) {
+    this.postId = postId;
+    this.type = type;
+    this.recruitEndAt = recruitEndAt;
+    this.progressWay = progressWay;
+    this.title = title;
+    this.positions = positions;
+    this.stacks = stacks;
+    this.nickname = nickname;
+    this.profileImageUrl = profileImageUrl;
+    this.viewCount = viewCount;
+    this.commentCount = commentCount;
+    this.isScraped = isScraped;
+    this.postStatus = postStatus;
+  }
+
+  static from(getCompletePostLists: GetCompletePostedList[]) {
+    return getCompletePostLists.map(
+      (getCompletePostLists) =>
+        new PostCompleteListResponse(
+          getCompletePostLists.postId,
+          getCompletePostLists.type,
+          getCompletePostLists.recruitEndAt,
+          getCompletePostLists.progressWay,
+          getCompletePostLists.title,
+          getCompletePostLists.positions,
+          getCompletePostLists.stacks,
+          getCompletePostLists.nickname,
+          getCompletePostLists.profileImageUrl,
+          getCompletePostLists.viewCount,
+          getCompletePostLists.commentCount,
+          getCompletePostLists.isScraped,
+          getCompletePostLists.postStatus
+        )
+    )
+  }
+}
+

--- a/src/service/post-detail.service.ts
+++ b/src/service/post-detail.service.ts
@@ -201,7 +201,7 @@ export class PostDetailService {
   }
 
   async cancelApplicationInfo(postId: number, memberId: number): Promise<void> {
-    const applicationInfo = await this.teamMemberRepository.findOneBy({ postId, memberId, status: TeamMemberStatus.READY });
+    const applicationInfo = await this.teamMemberRepository.findOneBy({ postId, memberId });
     if (applicationInfo === null) {
       throw new NotFoundException('해당 지원글을 찾을 수 없습니다.');
     }
@@ -251,7 +251,9 @@ export class PostDetailService {
     };
 
     const teamMember = await this.teamMemberRepository.findOneBy({ postId, memberId });
-    if (!teamMember || !memberId) {
+    if (
+      !teamMember || typeof (memberId) === 'undefined'
+      || (teamMember && teamMember.status === TeamMemberStatus.REJECT)) {
       return PostApplyStatus.NOT_APPLIED;
     }
     else {

--- a/src/service/post-detail.service.ts
+++ b/src/service/post-detail.service.ts
@@ -11,6 +11,7 @@ import { Member } from 'src/entity/member.entity';
 import { PostScrap } from 'src/entity/post-scrap.entity';
 import { PostView } from 'src/entity/post-view.entity';
 import { Post } from "src/entity/post.entity";
+import { TeamInvite } from 'src/entity/team-invite.entity';
 import { TeamMember } from "src/entity/team-member.entity";
 import { GetAllPostDetailTuple, PostDetailQueryRepository } from "src/repository/post-detail.query-repository";
 import { Repository } from "typeorm";
@@ -23,6 +24,7 @@ export class PostDetailService {
     @InjectRepository(PostView) private readonly postViewRepository: Repository<PostView>,
     @InjectRepository(Member) private readonly memberRepository: Repository<Member>,
     @InjectRepository(PostScrap) private readonly postScrapRepository: Repository<PostScrap>,
+    @InjectRepository(TeamInvite) private readonly teamInviteRepository: Repository<TeamInvite>,
     private readonly postDetailQueryRepository: PostDetailQueryRepository) { }
 
   async getPostDetail(postId: number, memberId?: number): Promise<GetPostDetailDto> {
@@ -212,7 +214,18 @@ export class PostDetailService {
     if (applicationInfo === null) {
       throw new NotFoundException('해당 지원글을 찾을 수 없습니다.');
     }
+    const teamInviteId = applicationInfo.teamInviteId
+    if (applicationInfo.inviteType === TeamInviteType.OTHERS && teamInviteId !== null) {
+      const teamInviteInfo = await this.teamInviteRepository.findOneBy({ id: teamInviteId });
+
+      if (teamInviteInfo === null) {
+        throw new NotFoundException('해당 초대를 찾을 수 없습니다.');
+      }
+      await this.teamInviteRepository.remove(teamInviteInfo);
+    }
     await this.teamMemberRepository.remove(applicationInfo);
+
+
   }
 
 

--- a/src/service/post-detail.service.ts
+++ b/src/service/post-detail.service.ts
@@ -264,7 +264,8 @@ export class PostDetailService {
       return PostApplyStatus.NOT_APPLIED;
     }
     else {
-      if (teamMember.inviteType === TeamInviteType.SELF) {
+      if (teamMember.inviteType === TeamInviteType.SELF ||
+        (teamMember.inviteType === TeamInviteType.OTHERS && teamMember.status === TeamMemberStatus.ACCEPT)) {
         return PostApplyStatus.APPLIED;
       }
       else {

--- a/src/service/post-detail.service.ts
+++ b/src/service/post-detail.service.ts
@@ -218,10 +218,10 @@ export class PostDetailService {
     if (applicationInfo.inviteType === TeamInviteType.OTHERS && teamInviteId !== null) {
       const teamInviteInfo = await this.teamInviteRepository.findOneBy({ id: teamInviteId });
 
-      if (teamInviteInfo === null) {
-        throw new NotFoundException('해당 초대를 찾을 수 없습니다.');
+      if (teamInviteInfo) {
+        await this.teamInviteRepository.remove(teamInviteInfo);
       }
-      await this.teamInviteRepository.remove(teamInviteInfo);
+
     }
     await this.teamMemberRepository.remove(applicationInfo);
 

--- a/src/service/post-list.service.ts
+++ b/src/service/post-list.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from "@nestjs/common";
 import { InjectRepository } from "@nestjs/typeorm";
 import { PaginationRequest } from "src/common/pagination/pagination-request";
+import { GetCompletePostedList } from "src/dto/get-post-complete.dto";
 import { GetPostListDto, GetPostedList } from "src/dto/get-post-list.dto";
 import { SearchPostList } from "src/dto/request/search-post-list.request";
 import { Post } from "src/entity/post.entity";
@@ -79,7 +80,7 @@ export class PostListService {
     const totalCount = await this.postListQueryRepository.getAllMyCompletedPostCount(memberId);
 
     const getMyCompletedPost = myCompletedPostTuples.map((postList) =>
-      GetPostedList.from(postList));
+      GetCompletePostedList.from(postList));
     return { getMyCompletedPost, totalCount };
   }
 }


### PR DESCRIPTION
### 개요  
applyStatus 쿼리 수정 작업을 진행하였습니다.
### 예상 리뷰시간  
3분
### 상세내용
지원 후, 수락 받고 취소 가능하게 변경 및 지원/초대 거절 시 Not Applied로 변경했습니다.
teamMember가 reject 상태일 때, 다시 신청하면 READY로 바뀌도록 변경하였습니다.
나의 스터디에서, postStatus 부분 수정 및 myCompletedPost에서 새로운 타입을 내려주었습니다.
스터디 초대된 것 수락하고 지원 취소 시, 해당 TeamInvite도 삭제하였습니다.
### 특이사항
