### PR TITLE
나의 대기중인 스터디 목록 api 추가

### DIFF
--- a/src/controller/my-post-controller.ts
+++ b/src/controller/my-post-controller.ts
@@ -67,5 +67,18 @@ export class MyPostController {
     })
   }
 
+  @ApiOperation({ summary: '내가 대기중인 스터디 목록' })
+  @ApiPaginatedResponse(PostListResponse)
+  @Get('/waiting/list')
+  async getMyWaitingPost(@Query() paginationRequest: PaginationRequest, @Req() req)
+    : Promise<PaginationResponse<PostListResponse>> {
+    const { getMyWaitingPost, totalCount } = await this.postListService.getMyWaitingPost(paginationRequest, req.user.id);
+    return PaginationResponse.of({
+      data: PostListResponse.from(getMyWaitingPost),
+      options: paginationRequest,
+      totalCount
+    })
+  }
+
 
 }

--- a/src/repository/post-list.query-repository.ts
+++ b/src/repository/post-list.query-repository.ts
@@ -422,6 +422,55 @@ export class PostListQueryRepository {
       .orWhere('(team_member.member_id = :memberId AND team_member.status = :teamMemberStatus))', { memberId, teamMemberStatus: TeamMemberStatus.ACCEPT })
       .andWhere('post.deletedAt IS NULL')
   }
+
+  async getAllMyWaitingPost(paginationRequest: PaginationRequest, memberId: number)
+    : Promise<GetAllPostListTuple[]> {
+    const myWaitingPostInfo = await this.dataSource
+      .createQueryBuilder()
+      .from(Post, 'post')
+      .innerJoin(Member, 'member', 'member.id = post.member_id')
+      .innerJoin(TeamMember, 'team_member', 'post.id = team_member.post_id')
+      .leftJoin(PostScrap, 'post_scrap', 'post_scrap.post_id = post.id AND post_scrap.member_id = :memberId', { memberId })
+      .where('post.status = :status', { status: PostStatus.READY })
+      .andWhere('(post.member_id = :memberId', { memberId })
+      .orWhere('(team_member.member_id = :memberId AND team_member.status = :teamMemberStatus))', { memberId, teamMemberStatus: TeamMemberStatus.ACCEPT })
+      .andWhere('post.deletedAt IS NULL')
+      .select([
+        'post.id as postId',
+        'post.type as type',
+        'post.recruitEndAt as recruitEndAt',
+        'post.progressWay as progressWay',
+        'post.title as title',
+        'post.position as positions',
+        'post.stack as stacks',
+        'member.nickname as nickname',
+        'member.profileImageUrl as profileImageUrl',
+        'post.viewCount as viewCount',
+        'post.commentCount as commentCount',
+        'CASE WHEN post_scrap.id IS NOT NULL THEN true ELSE false END as isScraped'
+      ])
+      .limit(paginationRequest.take)
+      .offset(paginationRequest.getSkip())
+      .orderBy('post.created_at', paginationRequest.order)
+      .getRawMany();
+    return plainToInstance(GetAllPostListTuple, myWaitingPostInfo);
+  }
+
+  async getAllMyWaitingPostCount(memberId: number): Promise<number> {
+    return await this.getMyWaitingPostBaseQuery(memberId).getCount();
+  }
+
+  private getMyWaitingPostBaseQuery(memberId: number) {
+    return this.dataSource
+      .createQueryBuilder()
+      .from(Post, 'post')
+      .innerJoin(TeamMember, 'team_member', 'post.id = team_member.post_id')
+      .where('post.status = :status', { status: PostStatus.READY })
+      .andWhere('(post.member_id = :memberId', { memberId })
+      .orWhere('(team_member.member_id = :memberId AND team_member.status = :teamMemberStatus))', { memberId, teamMemberStatus: TeamMemberStatus.ACCEPT })
+      .andWhere('post.deletedAt IS NULL')
+  }
+
 }
 
 export class GetAllPostListTuple {

--- a/src/service/post-list.service.ts
+++ b/src/service/post-list.service.ts
@@ -83,4 +83,13 @@ export class PostListService {
       GetCompletePostedList.from(postList));
     return { getMyCompletedPost, totalCount };
   }
+
+  async getMyWaitingPost(paginationRequest: PaginationRequest, memberId: number) {
+    const myWaitingPostTuples = await this.postListQueryRepository.getAllMyWaitingPost(paginationRequest, memberId);
+    const totalCount = await this.postListQueryRepository.getAllMyWaitingPostCount(memberId);
+
+    const getMyWaitingPost = myWaitingPostTuples.map((postList) =>
+      GetPostedList.from(postList));
+    return { getMyWaitingPost, totalCount };
+  }
 }


### PR DESCRIPTION
### 개요  
나의 대기중인 스터디 목록 api를 추가했습니다.

### 예상 리뷰시간  
1분
### 상세내용
스터디가 모집 중이고, 유저의 상태가 수락하거나 수락받은 상태일 때의 목록을 불러왔습니다.
### 특이사항
